### PR TITLE
Httpsupgrades November 2024 updates - added non-normative examples and changed Https upgrade step

### DIFF
--- a/fetch.bs
+++ b/fetch.bs
@@ -4621,8 +4621,6 @@ steps:
 
  <li><p><a>Upgrade <var>request</var> to a potentially trustworthy URL, if appropriate</a>.
 
- <li><p>Optionally, run <a>upgrade an HTTP request</a> algorithm on <var>request</var>.
-
  <li><p><a>Upgrade a mixed content <var>request</var> to a potentially trustworthy URL, if appropriate</a>.
 
  <li><p>If <a lt="block bad port">should <var>request</var> be blocked due to a bad port</a>,
@@ -4671,6 +4669,8 @@ steps:
   agents might need to perform DNS operations earlier, consult local DNS caches, or wait until later
   in the fetch algorithm and potentially unwind logic on discovering the need to change
   <var>request</var>'s <a for=request>current URL</a>'s <a for=url>scheme</a>.
+
+ <li><p>Optionally, run <a>upgrade an HTTP request</a> algorithm on <var>request</var>.
 
  <li><p>If <var>recursive</var> is false, then run the remaining steps <a>in parallel</a>.
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3410,13 +3410,18 @@ requests, in order to quickly initiate a fallback HTTP fetch.
 request to <code>http://a.com</code> will be upgraded to <code>https://a.com</code>, but the fetch
 will fail. A fallback request will be initiated to <code>http://a.com</code>.
 
-<p id=example-https-upgrade-allowlist class=example><code>site.test</code> serves
-<code>http://site.test</code> but refuses connections on <code>https://site.test</code>. Upon
-first request and fallback to <code>http://site.test</code>, the user agent stores the hostname
-in an allowlist with an expiration time of 7 days. In a future request, if <code>site.test</code>
-is still in this allowlist, the user agent will not upgrade <code>http://site.test</code> to
-<code>https://site.test</code>. The user agent will also set the new expiration time of the
-allowlist entry for <code>site.test</code> to 7 days from now.
+<p id=example-https-upgrade-allowlist class=example><code>a.com</code> serves
+<code>http://a.com</code> but refuses connections on <code>https://a.com</code>. Upon
+first request and fallback to <code>http://a.com</code>, the user agent stores the hostname
+in an allowlist with an expiration time of 7 days. In a future request, if <code>a.com</code>
+is still in this allowlist, the user agent will not upgrade <code>http://a.com</code> to
+<code>https://a.com</code>. The user agent will also set the new expiration time of the
+allowlist entry for <code>a.com</code> to 7 days from now.
+
+<p id=example-https-upgrade-ports class=example><code>a.com</code> serves
+<code>http://a.com:8080</code>. When a site is served from a non-default HTTP port, it's unlikely
+that the corresponding HTTPS URL is served from the default port either. Therefore, user agent
+doesn't upgrade requests to <code>http://a.com:8080.</code>
 
 
 

--- a/fetch.bs
+++ b/fetch.bs
@@ -3420,7 +3420,7 @@ allowlist entry for <code>a.com</code> to 7 days from now.
 
 <p id=example-https-upgrade-ports class=example><code>a.com</code> serves
 <code>http://a.com:8080</code>. When a site is served from a non-default HTTP port, it's unlikely
-that the corresponding HTTPS URL is served from the default port either. Therefore, user agent
+that the corresponding HTTPS URL is served from the default port either. Therefore, the user agent
 doesn't upgrade requests to <code>http://a.com:8080.</code>
 
 <p id=example-https-upgrade-redirect-loop class=example><code>a.com</code> serves

--- a/fetch.bs
+++ b/fetch.bs
@@ -3423,6 +3423,13 @@ allowlist entry for <code>a.com</code> to 7 days from now.
 that the corresponding HTTPS URL is served from the default port either. Therefore, user agent
 doesn't upgrade requests to <code>http://a.com:8080.</code>
 
+<p id=example-https-upgrade-redirect-loop class=example><code>a.com</code> serves
+<code>http://a.com</code> and <code>https://a.com</code>. The latter redirects to the former.
+An eligible request to <code>http://a.com</code> will be upgraded to
+<code>https://a.com</code> and will be redirected back to <code>http://a.com</code>.
+The user agent will detect this as a redirect loop, treat it as a failed upgrade and initiate a
+fallback navigation to <code>http://a.com</code>.
+
 
 
 <h2 id=http-extensions>HTTP extensions</h2>


### PR DESCRIPTION
Chris, could you PTAL before I pull these into the actual PR?

I had to move the upgrade step (section 4.1.5 before, 4.1.11 now) right after the HSTS step to fix the issue at https://github.com/whatwg/fetch/pull/1655#issuecomment-2208627512

However, the HTTPS upgrade now happens after the mixed content upgrade step (4.1.5 in the unmodified spec). So perhaps mixed content upgrade should happen after the HSTS upgrade (4.1.10 in the unmodified spec) in the first place? Do you think this is a bug in the unmodified spec or am I missing something?